### PR TITLE
Expand embed's default width and height

### DIFF
--- a/app/assets/javascripts/mediaelement_rails/mediaelement.js
+++ b/app/assets/javascripts/mediaelement_rails/mediaelement.js
@@ -1227,8 +1227,8 @@ mejs.HtmlMediaElementShim = {
 	createPlugin:function(playback, options, poster, autoplay, preload, controls) {
 		var 
 			htmlMediaElement = playback.htmlMediaElement,
-			width = 1,
-			height = 1,
+			width = 45,
+			height = 45,
 			pluginid = 'me_' + playback.method + '_' + (mejs.meIndex++),
 			pluginMediaElement = new mejs.PluginMediaElement(pluginid, playback.method, playback.url),
 			container = document.createElement('div'),


### PR DESCRIPTION
Fixes #https://github.com/avalonmediasystem/avalon/issues/1798 
In chrome, if an embeded swf is too small (ours was 1x1) it doesn't consider that content and will automatically disable flash on that page. This fix bumps up the size to 45x45, so that chrome will run it again.
This is what the 1x1 not working looks like with the disabled plugin icon->
![image](https://cloud.githubusercontent.com/assets/5091130/24566025/bb0568a8-1625-11e7-90bd-120a7431ea0e.png)

And this is it working:
![image](https://cloud.githubusercontent.com/assets/5091130/24566095/1c41970e-1626-11e7-836c-fa7cb6ef3574.png)

